### PR TITLE
Tighten MPI rank checks in Ethier tests

### DIFF
--- a/short_tests/NekTests.py
+++ b/short_tests/NekTests.py
@@ -1206,10 +1206,12 @@ class Ethier(NekTestCase):
         self.build_nek()
         self.run_nek(step_limit=1000)
 
-        np_err = self.get_value_from_log(label="Number of MPI ranks :", column=-1, row=0)
-        self.assertAlmostEqualDelayed(
-            np_err, target_val=self.parallel_procs, delta=0, label="np err"
+        np_err = int(
+            self.get_value_from_log(
+                label="Number of MPI ranks :", column=-1, row=0
+            )
         )
+        self.assertEqual(np_err, self.parallel_procs, "Number of MPI ranks mismatch")
 
         herr = self.get_value_from_log(label="hpts err", column=-1, row=-1)
         self.assertAlmostEqualDelayed(
@@ -1261,10 +1263,12 @@ class Ethier(NekTestCase):
 
         self.run_nek(step_limit=1000)
 
-        np_err = self.get_value_from_log(label="Number of MPI ranks :", column=-1, row=0)
-        self.assertAlmostEqualDelayed(
-            np_err, target_val=self.parallel_procs, delta=0, label="np err"
+        np_err = int(
+            self.get_value_from_log(
+                label="Number of MPI ranks :", column=-1, row=0
+            )
         )
+        self.assertEqual(np_err, self.parallel_procs, "Number of MPI ranks mismatch")
 
         gmres = self.get_value_from_log("gmres ", column=-7)
         self.assertAlmostEqualDelayed(


### PR DESCRIPTION
## Summary
- convert the parsed MPI rank count in Ethier tests to an integer
- use a strict equality assertion for the recorded number of ranks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0c3579ec83299c2de2a55219ccc8)