### PR TITLE
Refresh symlinks during third-party installs

### DIFF
--- a/3rd_party/cvode/install
+++ b/3rd_party/cvode/install
@@ -75,7 +75,7 @@ set +x
 make install -j4
 
 cd $ROOT
-ln -s $DIR/ $PREFIX
+ln -sfn $DIR/ $PREFIX
 
 if [ "$?" -eq 0 ]; then
   cd $ROOT

--- a/3rd_party/gslib/install
+++ b/3rd_party/gslib/install
@@ -57,7 +57,7 @@ make -j4 $GSLIB_OPT
 set +x
 
 cd $ROOT
-ln -s $DIR/ $PREFIX
+ln -sfn $DIR/ $PREFIX
 
 if [ "$?" -eq 0 ]; then
   cd $ROOT

--- a/3rd_party/hypre/install
+++ b/3rd_party/hypre/install
@@ -65,7 +65,7 @@ set +x
 make -j4 install
 
 cd $ROOT
-ln -s $DIR/ $PREFIX
+ln -sfn $DIR/ $PREFIX
 
 if [ "$?" -eq 0 ]; then
   cd $ROOT

--- a/3rd_party/parMETIS/install
+++ b/3rd_party/parMETIS/install
@@ -68,7 +68,7 @@ cp ./metis/include/metis.h ../include
 cp ./libparmetis/defs.h ../include
 
 cd $ROOT
-ln -s $DIR/ $PREFIX
+ln -sfn $DIR/ $PREFIX
 
 if [ "$?" -eq 0 ]; then
   cd $ROOT

--- a/3rd_party/parRSB/install
+++ b/3rd_party/parRSB/install
@@ -54,7 +54,7 @@ make lib install $PARRSB_OPT
 set +x
 
 cd $ROOT
-ln -s $DIR/ $PREFIX
+ln -sfn $DIR/ $PREFIX
 
 if [ "$?" -eq 0 ]; then
   cd $ROOT


### PR DESCRIPTION
## Summary
- ensure third-party install scripts force-upgrade the version symlink when rebuilding

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ba6cdda088329b09b51bd998c1dfc)